### PR TITLE
Fix exception when you use an external model form

### DIFF
--- a/tests/artist_app/forms.py
+++ b/tests/artist_app/forms.py
@@ -19,11 +19,11 @@ class ArtistForm(forms.ModelForm):
 
     class Meta:
         model = Artist
-        fields = ['name']
+        fields = ["name"]
 
     def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop('request', None)
-        self.vega_extra_kwargs = kwargs.pop('vega_extra_kwargs', dict())
+        self.request = kwargs.pop("request", None)
+        self.vega_extra_kwargs = kwargs.pop("vega_extra_kwargs", dict())
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_tag = True
@@ -31,15 +31,23 @@ class ArtistForm(forms.ModelForm):
         self.helper.form_show_labels = True
         self.helper.html5_required = True
         self.helper.include_media = False
-        self.helper.form_id = 'artist'
+        self.helper.form_id = "artist"
         self.helper.layout = Layout(
-            Field('name',),
+            Field("name"),
             FormActions(
-                Submit('submitBtn',
-                       'Submit',
-                       css_class='btn-success btn-block'),
-            )
+                Submit("submitBtn", "Submit", css_class="btn-success btn-block")
+            ),
         )
+
+
+class PlainArtistForm(forms.ModelForm):
+    """
+    Artist ModelForm class with nothing extra
+    """
+
+    class Meta:
+        model = Artist
+        fields = ["name"]
 
 
 class SongForm(forms.ModelForm):
@@ -49,11 +57,11 @@ class SongForm(forms.ModelForm):
 
     class Meta:
         model = Song
-        fields = ['name', 'artist']
+        fields = ["name", "artist"]
 
     def __init__(self, *args, **kwargs):
-        self.request = kwargs.pop('request', None)
-        self.vega_extra_kwargs = kwargs.pop('vega_extra_kwargs', dict())
+        self.request = kwargs.pop("request", None)
+        self.vega_extra_kwargs = kwargs.pop("vega_extra_kwargs", dict())
         super().__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_tag = True
@@ -61,19 +69,15 @@ class SongForm(forms.ModelForm):
         self.helper.form_show_labels = True
         self.helper.html5_required = True
         self.helper.include_media = False
-        self.helper.form_id = 'song'
+        self.helper.form_id = "song"
         self.helper.layout = Layout(
-            Field('name',),
-            Field('artist',),
+            Field("name"),
+            Field("artist"),
             FormActions(
-                Submit('submitBtn',
-                       'Submit',
-                       css_class='btn-success btn-block'),
-            )
+                Submit("submitBtn", "Submit", css_class="btn-success btn-block")
+            ),
         )
 
 
 class CustomSearchForm(ListViewSearchForm):
     """Custom search form"""
-
-    pass

--- a/tests/artist_app/urls.py
+++ b/tests/artist_app/urls.py
@@ -5,6 +5,7 @@ from django.urls import path
 
 from . import views
 
+# pylint: disable=invalid-name
 artist_crud_patterns = views.ArtistCRUD().url_patterns()
 custom_artist_crud_patterns = views.CustomArtistCRUD().url_patterns()
 song_crud_patterns = views.SongCRUD().url_patterns()
@@ -12,14 +13,23 @@ protected_crud_song_patterns = views.CustomSongCRUD().url_patterns()
 perms_crud_song_patterns = views.PermsSongCRUD().url_patterns()
 custom_default_patterns = views.CustomDefaultActions().url_patterns()
 patterns_42 = views.Artist42CRUD().url_patterns()
+plainform_patterns = views.PlainFormCRUD().url_patterns()
 
 
-urlpatterns = [
-    path('list/artists/', views.ArtistListView.as_view()),
-    path('edit/artists/create/', views.ArtistCreate.as_view()),
-    path('view/artists/view/<int:pk>', views.ArtistRead.as_view()),
-    path('edit/artists/edit/<int:pk>', views.ArtistUpdate.as_view()),
-    path('edit/artists/delete/<int:pk>', views.ArtistDelete.as_view()),
-] + artist_crud_patterns + song_crud_patterns + custom_artist_crud_patterns +\
-    protected_crud_song_patterns + custom_default_patterns +\
-    perms_crud_song_patterns + patterns_42
+urlpatterns = (
+    [
+        path("list/artists/", views.ArtistListView.as_view()),
+        path("edit/artists/create/", views.ArtistCreate.as_view()),
+        path("view/artists/view/<int:pk>", views.ArtistRead.as_view()),
+        path("edit/artists/edit/<int:pk>", views.ArtistUpdate.as_view()),
+        path("edit/artists/delete/<int:pk>", views.ArtistDelete.as_view()),
+    ]
+    + artist_crud_patterns
+    + song_crud_patterns
+    + custom_artist_crud_patterns
+    + protected_crud_song_patterns
+    + custom_default_patterns
+    + perms_crud_song_patterns
+    + patterns_42
+    + plainform_patterns
+)

--- a/tests/artist_app/views.py
+++ b/tests/artist_app/views.py
@@ -267,5 +267,5 @@ class PlainFormCRUD(VegaCRUDView):
     model = Artist
     permissions_actions = None
     form_class = PlainArtistForm
-    actions = ["create", "update"]
+    actions = ["create", "update", "list"]
     crud_path = "plain-form"

--- a/tests/artist_app/views.py
+++ b/tests/artist_app/views.py
@@ -1,16 +1,24 @@
 """
 Module for vega-admin test views
 """
+from typing import List, Union
+
 from django.views.generic import TemplateView
 
 from braces.views import LoginRequiredMixin, PermissionRequiredMixin
-
 from django_filters import FilterSet
-from vega_admin.mixins import SimpleURLPatternMixin
-from vega_admin.views import (VegaCreateView, VegaCRUDView, VegaDeleteView,
-                              VegaListView, VegaUpdateView, VegaDetailView)
 
-from .forms import ArtistForm, CustomSearchForm, SongForm
+from vega_admin.mixins import SimpleURLPatternMixin
+from vega_admin.views import (
+    VegaCreateView,
+    VegaCRUDView,
+    VegaDeleteView,
+    VegaDetailView,
+    VegaListView,
+    VegaUpdateView,
+)
+
+from .forms import ArtistForm, CustomSearchForm, PlainArtistForm, SongForm
 from .models import Artist, Song
 from .tables import ArtistTable
 
@@ -83,14 +91,14 @@ class SongCRUD(VegaCRUDView):
     """
 
     model = Song
-    protected_actions = None
-    permissions_actions = None
-    list_fields = ["name", "artist", ]
-    read_fields = ["name", "artist", ]
+    protected_actions: Union[None, List[str]] = None
+    permissions_actions: Union[None, List[str]] = None
+    list_fields = ["name", "artist"]
+    read_fields = ["name", "artist"]
     table_attrs = {"class": "song-table"}
-    table_actions = ["create", "update", "delete", ]
-    create_fields = ["name", "artist", ]
-    update_fields = ["name", ]
+    table_actions = ["create", "update", "delete"]
+    create_fields = ["name", "artist"]
+    update_fields = ["name"]
 
 
 class CustomSongCRUD(SongCRUD):
@@ -100,19 +108,16 @@ class CustomSongCRUD(SongCRUD):
 
     class CustomListView(ArtistListView):  # pylint: disable=too-many-ancestors
         """custom list view"""
-        pass
 
     class FooView(SimpleURLPatternMixin, TemplateView):
         """random template view"""
+
         template_name = "artist_app/empty.html"
 
-    protected_actions = ["create", "update", "delete", "template", "view", ]
-    permissions_actions = None
+    protected_actions = ["create", "update", "delete", "template", "view"]
+    permissions_actions: Union[None, List[str]] = None
     crud_path = "private-songs"
-    view_classes = {
-        "artists": CustomListView,
-        "template": FooView,
-    }
+    view_classes = {"artists": CustomListView, "template": FooView}
     form_fields = ["name", "artist"]
 
 
@@ -121,9 +126,8 @@ class PermsSongCRUD(CustomSongCRUD):
     CRUD view for songs with permissions protection
     """
 
-    protected_actions = [
-        "create", "update", "delete", "artists", "list", "view", ]
-    permissions_actions = ["create", "update", "delete", "artists", "view", ]
+    protected_actions = ["create", "update", "delete", "artists", "list", "view"]
+    permissions_actions = ["create", "update", "delete", "artists", "view"]
     crud_path = "hidden-songs"
     form_class = SongForm
 
@@ -144,23 +148,18 @@ class CustomDefaultActions(ArtistCRUD):
     # pylint: disable=too-many-ancestors
     class CustomCreateView(ArtistCreate):
         """custom Create view"""
-        pass
 
     class CustomUpdateView(ArtistUpdate):
         """custom Update view"""
-        pass
 
     class CustomListView(ArtistListView):
         """custom list view"""
-        pass
 
     class CustomDeleteView(ArtistDelete):
         """custom Delete view"""
-        pass
 
     class CustomReadView(ArtistRead):
         """custom Read view"""
-        pass
 
     view_classes = {
         "list": CustomListView,
@@ -178,14 +177,13 @@ class BrokenCRUD(VegaCRUDView):
     # pylint: disable=too-many-ancestors
     class BrokenListView(LoginRequiredMixin, VegaListView):
         """View that is broken"""
+
         model = Artist
 
     model = Artist
     actions = ["break"]
     permissions_actions = actions
-    view_classes = {
-        "break": BrokenListView,
-    }
+    view_classes = {"break": BrokenListView}
     crud_path = "broken"
 
 
@@ -199,19 +197,18 @@ class Artist42CRUD(VegaCRUDView):
         """
         Custom list view that has PermissionRequiredMixin
         """
+
         model = Artist
 
     class FooView(SimpleURLPatternMixin, TemplateView):
         """random template view"""
+
         template_name = "artist_app/empty.html"
 
     model = Artist
     actions = ["list", "other"]
     permissions_actions = actions
-    view_classes = {
-        "list": CustListView,
-        "other": FooView,
-    }
+    view_classes = {"list": CustListView, "other": FooView}
     crud_path = "42"
 
 
@@ -238,8 +235,8 @@ class FilterSongCRUD(VegaCRUDView):
     """
 
     model = Song
-    actions = ["list", ]
-    filter_fields = ["name", "artist", ]
+    actions = ["list"]
+    filter_fields = ["name", "artist"]
     crud_path = "filters"
     search_form_class = None
 
@@ -254,11 +251,21 @@ class Filter2SongCRUD(VegaCRUDView):
 
         class Meta:
             model = Song
-            fields = ["artist", ]
+            fields = ["artist"]
 
     model = Song
-    actions = ["list", ]
-    search_fields = ["artist__name", ]
+    actions = ["list"]
+    search_fields = ["artist__name"]
     filter_class = SongFilter
     crud_path = "filters2"
     search_form_class = None
+
+
+class PlainFormCRUD(VegaCRUDView):
+    """Vega CRUD view created with plain form"""
+
+    model = Artist
+    permissions_actions = None
+    form_class = PlainArtistForm
+    actions = ["create", "update"]
+    crud_path = "plain-form"

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -556,10 +556,10 @@ class TestCRUD(TestViewsBase):
         create_url = reverse("plain-form-create")
         update_url = reverse("plain-form-update", kwargs={"pk": artist.id})
 
-        # create
+        # create, should not result in exceptions esp. TypeError
         create_res = self.client.get(create_url)
         self.assertEqual(200, create_res.status_code)
 
-        # update
+        # update, should not result in exceptions esp. TypeError
         update_res = self.client.get(update_url)
         self.assertEqual(200, update_res.status_code)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 
 from model_mommy import mommy
 
-from .artist_app.forms import ArtistForm, CustomSearchForm
+from .artist_app.forms import ArtistForm, CustomSearchForm, PlainArtistForm
 from .artist_app.models import Artist
 from .artist_app.tables import ArtistTable
 from .artist_app.views import CustomDefaultActions, CustomSongCRUD
@@ -558,8 +558,10 @@ class TestCRUD(TestViewsBase):
 
         # create, should not result in exceptions esp. TypeError
         create_res = self.client.get(create_url)
+        self.assertIsInstance(create_res.context["form"], PlainArtistForm)
         self.assertEqual(200, create_res.status_code)
 
         # update, should not result in exceptions esp. TypeError
         update_res = self.client.get(update_url)
+        self.assertIsInstance(update_res.context["form"], PlainArtistForm)
         self.assertEqual(200, update_res.status_code)

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -16,6 +16,7 @@ from .artist_app.views import CustomDefaultActions, CustomSongCRUD
 from .test_views import TestViewsBase
 
 
+# pylint: disable=too-many-locals,line-too-long,too-many-statements,too-many-public-methods  # noqa
 @override_settings(
     VEGA_ACTION_COLUMN_NAME="Actions",
     ROOT_URLCONF="tests.artist_app.urls",
@@ -35,8 +36,7 @@ class TestCRUD(TestViewsBase):
         self.assertEqual(
             "/artist_app.artist/create/", reverse("artist_app.artist-create")
         )
-        self.assertEqual(
-            "/artist_app.artist/list/", reverse("artist_app.artist-list"))
+        self.assertEqual("/artist_app.artist/list/", reverse("artist_app.artist-list"))
         self.assertEqual(
             f"/artist_app.artist/delete/{artist.pk}/",
             reverse("artist_app.artist-delete", kwargs={"pk": artist.pk}),
@@ -50,12 +50,8 @@ class TestCRUD(TestViewsBase):
             reverse("artist_app.artist-update", kwargs={"pk": artist.pk}),
         )
         # custom actions
-        self.assertEqual(
-            "/private-songs/artists/", reverse("private-songs-artists")
-        )
-        self.assertEqual(
-            "/private-songs/template/", reverse("private-songs-template")
-        )
+        self.assertEqual("/private-songs/artists/", reverse("private-songs-artists"))
+        self.assertEqual("/private-songs/template/", reverse("private-songs-template"))
 
     def test_create(self):
         """
@@ -70,13 +66,11 @@ class TestCRUD(TestViewsBase):
         # test what happens for a form error
         res = self.client.post(url, {})
         self.assertEqual(res.status_code, 200)
-        self.assertTrue(
-            settings.VEGA_FORM_INVALID_TXT in res.cookies["messages"].value)
+        self.assertTrue(settings.VEGA_FORM_INVALID_TXT in res.cookies["messages"].value)
 
         # test content
         res = self.client.get(url)
-        self.assertEqual(
-            "/artist_app.artist/list/", res.context_data["vega_list_url"])
+        self.assertEqual("/artist_app.artist/list/", res.context_data["vega_list_url"])
         self.assertEqual(
             "/artist_app.artist/create/", res.context_data["vega_create_url"]
         )
@@ -96,21 +90,17 @@ class TestCRUD(TestViewsBase):
 
         # test content
         res = self.client.get(url)
-        self.assertEqual(
-            "/artist_app.artist/list/", res.context_data["vega_list_url"])
+        self.assertEqual("/artist_app.artist/list/", res.context_data["vega_list_url"])
         self.assertEqual(
             "/artist_app.artist/create/", res.context_data["vega_create_url"]
         )
         self.assertEqual(artist.name, res.context_data["vega_object_title"])
-        self.assertEqual(
-            ["id", "name", ], res.context_data["vega_read_fields"])
+        self.assertEqual(["id", "name"], res.context_data["vega_read_fields"])
         self.assertDictEqual(
-            {"name": artist.name, "ID": artist.id},
-            res.context_data["vega_object_data"]
+            {"name": artist.name, "ID": artist.id}, res.context_data["vega_object_data"]
         )
         self.assertEqual(
-            f"/artist_app.artist/view/{artist.pk}/",
-            res.context_data["vega_read_url"],
+            f"/artist_app.artist/view/{artist.pk}/", res.context_data["vega_read_url"]
         )
         html = f"""<!doctype html><html lang="en"><head><meta charset="utf-8"><title> tt | professional artist</title></head><body><h3>tt</h3> <strong>ID</strong>: 436 <br /> <strong>name</strong>: tt <br /></body></html>"""  # noqa
         self.assertHTMLEqual(html, res.content.decode("utf-8"))
@@ -130,17 +120,17 @@ class TestCRUD(TestViewsBase):
         # test what happens for a form error
         res = self.client.post(url, {})
         self.assertEqual(res.status_code, 200)
-        self.assertTrue(
-            settings.VEGA_FORM_INVALID_TXT in res.cookies["messages"].value)
+        self.assertTrue(settings.VEGA_FORM_INVALID_TXT in res.cookies["messages"].value)
 
         # test content
         res = self.client.get(url)
-        self.assertEqual("/artist_app.artist/list/",
-                         res.context_data["vega_list_url"])
-        self.assertEqual("/artist_app.artist/create/",
-                         res.context_data["vega_create_url"])
-        self.assertEqual("/artist_app.artist/list/",
-                         res.context_data["vega_cancel_url"])
+        self.assertEqual("/artist_app.artist/list/", res.context_data["vega_list_url"])
+        self.assertEqual(
+            "/artist_app.artist/create/", res.context_data["vega_create_url"]
+        )
+        self.assertEqual(
+            "/artist_app.artist/list/", res.context_data["vega_cancel_url"]
+        )
         self.assertEqual(artist.name, res.context_data["vega_object_title"])
         self.assertEqual(
             f"/artist_app.artist/update/{artist.pk}/",
@@ -172,15 +162,13 @@ class TestCRUD(TestViewsBase):
             res, reverse("artist_app.artist-delete", kwargs={"pk": artist2.id})
         )
         self.assertTrue(
-            settings.VEGA_DELETE_PROTECTED_ERROR_TXT in
-            res.cookies["messages"].value
+            settings.VEGA_DELETE_PROTECTED_ERROR_TXT in res.cookies["messages"].value
         )
         self.assertTrue(Artist.objects.filter(id=artist2.id).exists())
 
         # test content
         res = self.client.get(url2)
-        self.assertEqual(
-            "/artist_app.artist/list/", res.context_data["vega_list_url"])
+        self.assertEqual("/artist_app.artist/list/", res.context_data["vega_list_url"])
         self.assertEqual(
             "/artist_app.artist/create/", res.context_data["vega_create_url"]
         )
@@ -208,8 +196,7 @@ class TestCRUD(TestViewsBase):
         url = reverse("artist_app.artist-list")
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(
-            "/artist_app.artist/list/", res.context_data["vega_list_url"])
+        self.assertEqual("/artist_app.artist/list/", res.context_data["vega_list_url"])
         self.assertEqual(
             "/artist_app.artist/create/", res.context_data["vega_create_url"]
         )
@@ -224,8 +211,7 @@ class TestCRUD(TestViewsBase):
         artists_view_url = reverse("private-songs-artists")
         res = self.client.get(artists_view_url)
         self.assertEqual(res.status_code, 200)
-        self.assertIsInstance(res.context["view"],
-                              CustomSongCRUD.CustomListView)
+        self.assertIsInstance(res.context["view"], CustomSongCRUD.CustomListView)
 
         template_view_url = reverse("private-songs-template")
         res = self.client.get(template_view_url)
@@ -239,35 +225,33 @@ class TestCRUD(TestViewsBase):
         url = reverse("custom-default-actions-list")
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
-        self.assertIsInstance(res.context["view"],
-                              CustomDefaultActions.CustomListView)
+        self.assertIsInstance(res.context["view"], CustomDefaultActions.CustomListView)
 
         url = reverse("custom-default-actions-create")
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
-        self.assertIsInstance(res.context["view"],
-                              CustomDefaultActions.CustomCreateView)
+        self.assertIsInstance(
+            res.context["view"], CustomDefaultActions.CustomCreateView
+        )
 
-        url = reverse(
-            "custom-default-actions-update", kwargs={"pk": artist.pk})
+        url = reverse("custom-default-actions-update", kwargs={"pk": artist.pk})
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
-        self.assertIsInstance(res.context["view"],
-                              CustomDefaultActions.CustomUpdateView)
+        self.assertIsInstance(
+            res.context["view"], CustomDefaultActions.CustomUpdateView
+        )
 
-        url = reverse(
-            "custom-default-actions-view", kwargs={"pk": artist.pk})
+        url = reverse("custom-default-actions-view", kwargs={"pk": artist.pk})
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
-        self.assertIsInstance(res.context["view"],
-                              CustomDefaultActions.CustomReadView)
+        self.assertIsInstance(res.context["view"], CustomDefaultActions.CustomReadView)
 
-        url = reverse(
-            "custom-default-actions-delete", kwargs={"pk": artist.pk})
+        url = reverse("custom-default-actions-delete", kwargs={"pk": artist.pk})
         res = self.client.get(url)
         self.assertEqual(res.status_code, 200)
-        self.assertIsInstance(res.context["view"],
-                              CustomDefaultActions.CustomDeleteView)
+        self.assertIsInstance(
+            res.context["view"], CustomDefaultActions.CustomDeleteView
+        )
 
     def test_list_options(self):
         """
@@ -306,11 +290,10 @@ class TestCRUD(TestViewsBase):
         url = reverse("artist_app.song-view", kwargs={"pk": song.id})
         # test content
         res = self.client.get(url)
-        self.assertEqual(
-            ["name", "artist", ], res.context_data["vega_read_fields"])
+        self.assertEqual(["name", "artist"], res.context_data["vega_read_fields"])
         self.assertDictEqual(
             {"name": song.name, "artist": str(artist)},
-            res.context_data["vega_object_data"]
+            res.context_data["vega_object_data"],
         )
         self.assertEqual(res.status_code, 200)
         html = f"""<!doctype html><html lang="en"><head><meta charset="utf-8"><title> Song 1 | Song</title></head><body><h3>Song 1</h3> <strong>name</strong>: Song 1 <br /> <strong>artist</strong>: Mosh <br /></body></html>"""  # noqa
@@ -321,8 +304,7 @@ class TestCRUD(TestViewsBase):
         Test CRUD update with options
         """
         artist = mommy.make("artist_app.Artist", name="Mosh")
-        song = mommy.make(
-            "artist_app.Song", name="Song 1", artist=artist)
+        song = mommy.make("artist_app.Song", name="Song 1", artist=artist)
         url = reverse("artist_app.song-update", kwargs={"pk": song.id})
         # test content
         res = self.client.get(url)
@@ -362,23 +344,12 @@ class TestCRUD(TestViewsBase):
 
     def test_get_permissions(self):
         """Test get_permissions"""
-        actions = [
-            "create",
-            "update",
-            "delete",
-            "template",
-            "view",
-            "list",
-            "artists",
-        ]
-        expected = [
-            f"artist_app.{action}_song" for action in actions
-        ]
+        actions = ["create", "update", "delete", "template", "view", "list", "artists"]
+        expected = [f"artist_app.{action}_song" for action in actions]
 
-        self.assertEqual(
-            set(expected), set(CustomSongCRUD().get_permissions()))
+        self.assertEqual(set(expected), set(CustomSongCRUD().get_permissions()))
 
-    @override_settings(LOGIN_URL='/list/artists/')
+    @override_settings(LOGIN_URL="/list/artists/")
     def test_login_protection(self):
         """
         Test login protection
@@ -426,7 +397,7 @@ class TestCRUD(TestViewsBase):
         list_res = self.client.get(list_url)
         self.assertEqual(200, list_res.status_code)
 
-    @override_settings(LOGIN_URL='/list/artists/')
+    @override_settings(LOGIN_URL="/list/artists/")
     def test_custom_view_login_protection(self):
         """Test custom views"""
         artists_view_url = reverse("private-songs-artists")
@@ -446,7 +417,7 @@ class TestCRUD(TestViewsBase):
         res2 = self.client.get(template_view_url)
         self.assertEqual(res2.status_code, 200)
 
-    @override_settings(LOGIN_URL='/list/artists/')
+    @override_settings(LOGIN_URL="/list/artists/")
     def test_permission_protection(self):
         """
         Test permission protection
@@ -491,7 +462,7 @@ class TestCRUD(TestViewsBase):
         self.assertEqual(200, template_res.status_code)
 
         # now login to ensure that even a logged in user needs perms
-        alice_user = mommy.make('auth.User', username='alice')
+        alice_user = mommy.make("auth.User", username="alice")
         self.client.force_login(alice_user)
 
         create_res = self.client.get(create_url)
@@ -522,7 +493,7 @@ class TestCRUD(TestViewsBase):
         self.assertEqual(200, template_res.status_code)
 
         # now log in with a user who HAS the permissions
-        bob_user = mommy.make('auth.User')
+        bob_user = mommy.make("auth.User")
         permissions = self._song_permissions()
         bob_user.user_permissions.add(*permissions)
         bob_user = User.objects.get(pk=bob_user.pk)
@@ -552,7 +523,7 @@ class TestCRUD(TestViewsBase):
     @override_settings(ROOT_URLCONF="tests.artist_app.broken_urls")
     def test_broken_permission_protection(self):
         """Test custom views"""
-        bob_user = mommy.make('auth.User')
+        bob_user = mommy.make("auth.User")
         permissions = self._song_permissions()
         bob_user.user_permissions.add(*permissions)
         bob_user = User.objects.get(pk=bob_user.pk)
@@ -563,7 +534,7 @@ class TestCRUD(TestViewsBase):
 
     def test_custom_permission_protection(self):
         """Test custom views"""
-        bob_user = mommy.make('auth.User')
+        bob_user = mommy.make("auth.User")
         permissions = self._artist_permissions()
         bob_user.user_permissions.add(*permissions)
         bob_user = User.objects.get(pk=bob_user.pk)
@@ -574,3 +545,21 @@ class TestCRUD(TestViewsBase):
 
         res = self.client.get(reverse("42-other"))
         self.assertEqual(200, res.status_code)
+
+    def test_external_modelform(self):
+        """Test that CRUD views created with external model forms work"""
+        artist = mommy.make("artist_app.Artist", name="Plain Jane")
+
+        bob_user = mommy.make("auth.User")
+        self.client.force_login(bob_user)
+
+        create_url = reverse("plain-form-create")
+        update_url = reverse("plain-form-update", kwargs={"pk": artist.id})
+
+        # create
+        create_res = self.client.get(create_url)
+        self.assertEqual(200, create_res.status_code)
+
+        # update
+        update_res = self.client.get(update_url)
+        self.assertEqual(200, update_res.status_code)

--- a/vega_admin/mixins.py
+++ b/vega_admin/mixins.py
@@ -267,7 +267,7 @@ class CRUDURLsMixin:
         """
         kwargs = super().get_form_kwargs()
         url_kwargs = {"cancel_url": self.get_list_url()}
-        kwargs["vega_extra_kwargs"] = url_kwargs
+        kwargs[settings.VEGA_MODELFORM_KWARG] = url_kwargs
         return kwargs
 
 

--- a/vega_admin/settings.py
+++ b/vega_admin/settings.py
@@ -21,6 +21,9 @@ VEGA_TEMPLATE = "basic"
 VEGA_FORCE_ORDERING = True
 VEGA_ORDERING_FIELD = ["-pk"]
 
+# model forms
+VEGA_MODELFORM_KWARG = "vega_extra_kwargs"
+
 # crispy forms
 VEGA_CRISPY_TEMPLATE_PACK = getattr(settings, "CRISPY_TEMPLATE_PACK", "bootstrap3")
 

--- a/vega_admin/views.py
+++ b/vega_admin/views.py
@@ -1,10 +1,11 @@
 """
 Views module
 """
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.forms import Form, ModelForm
 from django.urls import path, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.views.generic.base import View
@@ -13,7 +14,8 @@ from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django.views.generic.list import ListView
 
 from braces.views import FormMessagesMixin, LoginRequiredMixin, PermissionRequiredMixin
-from django_tables2 import SingleTableView
+from django_filters import FilterSet
+from django_tables2 import SingleTableView, Table
 from django_tables2.export.views import ExportMixin
 
 from vega_admin.forms import ListViewSearchForm
@@ -138,32 +140,32 @@ class VegaCRUDView:  # pylint: disable=too-many-public-methods
     straight away.
     """
 
-    actions = settings.VEGA_DEFAULT_ACTIONS
-    protected_actions = actions  # actions that require login
-    permissions_actions = actions
+    actions: List[str] = settings.VEGA_DEFAULT_ACTIONS
+    protected_actions: Union[None, List[str]] = actions  # actions that require login
+    permissions_actions: Union[None, List[str]] = actions
     view_classes: Dict[str, View] = {}
-    list_fields = None
-    read_fields = None
-    search_fields = None
-    filter_fields = None
-    filter_class = None
-    search_form_class = ListViewSearchForm
-    form_fields = None
-    create_fields = None
-    update_fields = None
-    table_attrs = None
-    table_actions = [
+    list_fields: Union[None, List[str]] = None
+    read_fields: Union[None, List[str]] = None
+    search_fields: Union[None, List[str]] = None
+    filter_fields: Union[None, List[str]] = None
+    filter_class: Union[None, FilterSet] = None
+    search_form_class: Union[None, Form, ModelForm] = ListViewSearchForm
+    form_fields: Union[None, List[str]] = None
+    create_fields: Union[None, List[str]] = None
+    update_fields: Union[None, List[str]] = None
+    table_attrs: Union[None, Dict[str, str]] = None
+    table_actions: List[str] = [
         settings.VEGA_READ_ACTION,
         settings.VEGA_UPDATE_ACTION,
         settings.VEGA_DELETE_ACTION,
     ]
-    form_class = None
-    create_form_class = None
-    update_form_class = None
-    table_class = None
+    form_class: Union[None, Form, ModelForm] = None
+    create_form_class: Union[None, Form, ModelForm] = None
+    update_form_class: Union[None, Form, ModelForm] = None
+    table_class: Union[None, Table] = None
     paginate_by = 25
-    crud_path = None
-    order_by = None
+    crud_path: Union[None, str] = None
+    order_by: Union[None, str] = None
 
     def __init__(self, model=None):
         """

--- a/vega_admin/views.py
+++ b/vega_admin/views.py
@@ -1,7 +1,7 @@
 """
 Views module
 """
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union, cast
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -33,6 +33,7 @@ from vega_admin.mixins import (
     VerboseNameMixin,
 )
 from vega_admin.utils import (
+    customize_modelform,
     get_filterclass,
     get_listview_form,
     get_modelform,
@@ -251,10 +252,14 @@ class VegaCRUDView:  # pylint: disable=too-many-public-methods
         """
         Get form class for create view
         """
+        chosen_form = None
         if self.create_form_class:
-            return self.create_form_class
+            chosen_form = self.create_form_class
         if self.form_class:
-            return self.form_class
+            chosen_form = self.form_class
+
+        if chosen_form is not None:
+            return customize_modelform(cast(Union[Form, ModelForm], chosen_form))
 
         return get_modelform(model=self.model, fields=self.get_createform_fields())
 
@@ -273,10 +278,14 @@ class VegaCRUDView:  # pylint: disable=too-many-public-methods
         """
         Get form class for create view
         """
+        chosen_form = None
         if self.update_form_class:
-            return self.update_form_class
+            chosen_form = self.update_form_class
         if self.form_class:
-            return self.form_class
+            chosen_form = self.form_class
+
+        if chosen_form is not None:
+            return customize_modelform(cast(Union[Form, ModelForm], chosen_form))
 
         return get_modelform(model=self.model, fields=self.get_updateform_fields())
 


### PR DESCRIPTION
Model forms that dont include the `vega_extra_kwargs` keyword argument fail with `TypeError: __init__() got an unexpected keyword argument 'vega_extra_kwargs'`.

Fix: #39